### PR TITLE
Pad single digit numbers with zeros to a width of two

### DIFF
--- a/src/com/hlidskialf/android/pomodoro/Pomodoro.java
+++ b/src/com/hlidskialf/android/pomodoro/Pomodoro.java
@@ -136,7 +136,7 @@ public class Pomodoro
     long left = when - System.currentTimeMillis();
     long min = Math.abs((long)(left / 60000));
     long sec = Math.abs((long)((left - min) / 1000) % 60);
-    return ((left < 0 ? "-" : "" )+ min+":"+sec);
+    return ((left < 0 ? "-" : "" ) + String.format("%02d", min) + ":" + String.format("%02d", sec));
   }
 
 

--- a/src/com/hlidskialf/android/widget/CountDownView.java
+++ b/src/com/hlidskialf/android/widget/CountDownView.java
@@ -43,7 +43,7 @@ public class CountDownView extends TextView
 
   public void stop()
   {
-    setText("0:0");
+    setText("00:00");
     mRunning = false;
   }
   public void pause()
@@ -61,6 +61,6 @@ public class CountDownView extends TextView
     long left = mUntil - System.currentTimeMillis();
     long min = Math.abs((long)(left / 60000));
     long sec = Math.abs((long)((left - min) / 1000) % 60);
-    setText((left < 0 ? "-" : "" )+ min+":"+sec);
+    setText((left < 0 ? "-" : "" ) + String.format("%02d", min) + ":" + String.format("%02d", sec));
   }
 }


### PR DESCRIPTION
This change gives the time display a more standardised/common look.  When
using the app, I was surprised to see the seconds display go down to a
single digit and the display not to be padded by a zero, as this is not the
behaviour a standard digital clock has.  This is the reasoning behind this
commit: to reduce surprise to users.
